### PR TITLE
Allow configurable host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.1.0] 2021-08-05
+
 ### Added
 
 - Added the ability to pass a different API hostname (e.g.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Added
+
+- Added the ability to pass a different API hostname (e.g.
+  `https://api.eu.onelogin.com`) to fetch data from different OneLogin
+  environments.
+
 ### Fixed
 
 - Fixed an issue introduced in 2.0.2 that inadvertantly stopped referencing the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed an issue introduced in 2.0.2 that inadvertantly stopped referencing the
+  `authToken` returned from the `/oauth2/token` call.
+
 ## 2.0.2 - 2021-08-03
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-onelogin",
-  "version": "2.0.2",
+  "version": "2.1.0",
   "description": "A JupiterOne managed integration for https://www.onelogin.com",
   "main": "dist/index.js",
   "repository": "https://github.com/jupiterone-io/graph-onelogin",

--- a/src/__recordings__/validateInvocation-success-providedApiHostname_1452567142/recording.har
+++ b/src/__recordings__/validateInvocation-success-providedApiHostname_1452567142/recording.har
@@ -1,0 +1,153 @@
+{
+  "log": {
+    "_recordingName": "validateInvocation:success:providedApiHostname",
+    "creator": {
+      "comment": "persister:JupiterOneIntegationFSPersister",
+      "name": "Polly.JS",
+      "version": "4.3.0"
+    },
+    "entries": [
+      {
+        "_id": "c657ef450aaa84fd701fe738f8fe8670",
+        "_order": 0,
+        "cache": {},
+        "request": {
+          "bodySize": 35,
+          "cookies": [],
+          "headers": [
+            {
+              "_fromType": "array",
+              "name": "content-type",
+              "value": "application/json"
+            },
+            {
+              "_fromType": "array",
+              "name": "authorization",
+              "value": "[REDACTED]"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept",
+              "value": "*/*"
+            },
+            {
+              "_fromType": "array",
+              "name": "content-length",
+              "value": "35"
+            },
+            {
+              "_fromType": "array",
+              "name": "user-agent",
+              "value": "node-fetch/1.0 (+https://github.com/bitinn/node-fetch)"
+            },
+            {
+              "_fromType": "array",
+              "name": "accept-encoding",
+              "value": "gzip,deflate"
+            },
+            {
+              "_fromType": "array",
+              "name": "connection",
+              "value": "close"
+            },
+            {
+              "name": "host",
+              "value": "api.us.onelogin.com"
+            }
+          ],
+          "headersSize": 444,
+          "httpVersion": "HTTP/1.1",
+          "method": "POST",
+          "postData": {
+            "mimeType": "application/json",
+            "params": [],
+            "text": "{\"grant_type\":\"client_credentials\"}"
+          },
+          "queryString": [],
+          "url": "https://api.us.onelogin.com/auth/oauth2/token"
+        },
+        "response": {
+          "bodySize": 351,
+          "content": {
+            "mimeType": "application/json; charset=utf-8",
+            "size": 351,
+            "text": "{\"status\":{\"error\":false,\"code\":200,\"type\":\"success\",\"message\":\"Success\"},\"data\":[{\"access_token\":\"d95965d98378ed391339fd194243612d643aa39d5aa88187a0d68fcd5a891ec4\",\"created_at\":\"2021-08-05T21:23:23.836Z\",\"expires_in\":36000,\"refresh_token\":\"b846caf092c8b414de0b312a19b5aab6b0ca905fdf9b9f2cc55def4d0060a8da\",\"token_type\":\"bearer\",\"account_id\":189185}]}"
+          },
+          "cookies": [],
+          "headers": [
+            {
+              "name": "date",
+              "value": "Thu, 05 Aug 2021 21:38:59 GMT"
+            },
+            {
+              "name": "content-type",
+              "value": "application/json; charset=utf-8"
+            },
+            {
+              "name": "transfer-encoding",
+              "value": "chunked"
+            },
+            {
+              "name": "status",
+              "value": "200 OK"
+            },
+            {
+              "name": "x-frame-options",
+              "value": "SAMEORIGIN"
+            },
+            {
+              "name": "x-xss-protection",
+              "value": "1; mode=block"
+            },
+            {
+              "name": "x-request-id",
+              "value": "610C5A73-68E4F113-CBDD-0A0B0533-01BB-104B5E-132D"
+            },
+            {
+              "name": "etag",
+              "value": "W/\"901639728448a78c2e53df1952adac0b\""
+            },
+            {
+              "name": "cache-control",
+              "value": "max-age=0, private, must-revalidate"
+            },
+            {
+              "name": "x-runtime",
+              "value": "0.021621"
+            },
+            {
+              "name": "strict-transport-security",
+              "value": "max-age=63072000; includeSubDomains;"
+            },
+            {
+              "name": "x-content-type-options",
+              "value": "nosniff"
+            },
+            {
+              "name": "connection",
+              "value": "close"
+            }
+          ],
+          "headersSize": 490,
+          "httpVersion": "HTTP/1.1",
+          "redirectURL": "",
+          "status": 200,
+          "statusText": "OK"
+        },
+        "startedDateTime": "2021-08-05T21:38:59.321Z",
+        "time": 557,
+        "timings": {
+          "blocked": -1,
+          "connect": -1,
+          "dns": -1,
+          "receive": 0,
+          "send": 0,
+          "ssl": -1,
+          "wait": 557
+        }
+      }
+    ],
+    "pages": [],
+    "version": "1.2"
+  }
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -48,7 +48,18 @@ export interface IntegrationConfig extends IntegrationInstanceConfig {
   /**
    * The Onelogin organization URL. Only used to create a weblink to the account.
    */
-  orgUrl?: string;
+  orgUrl?: string | null;
+
+  /**
+   * The Onelogin API hostname. https://developers.onelogin.com/api-docs/2/getting-started/dev-overview
+   *
+   * Options:
+   *   - https://api.us.onelogin.com
+   *   - https://api.eu.onelogin.com
+   *
+   * Defaults to https://api.us.onelogin.com.
+   */
+  apiHostname?: string | null;
 }
 
 export async function validateInvocation(

--- a/src/converters/AccountEntityConverter.ts
+++ b/src/converters/AccountEntityConverter.ts
@@ -14,6 +14,6 @@ export function createAccountEntity(account: Account): AccountEntity {
     _type: ACCOUNT_ENTITY_TYPE,
     displayName: account.name,
     name: account.name,
-    webLink: account.orgUrl,
+    webLink: account.orgUrl || undefined,
   };
 }

--- a/src/onelogin/OneLoginClient.ts
+++ b/src/onelogin/OneLoginClient.ts
@@ -173,7 +173,8 @@ export default class OneLoginClient {
     )) as AccessTokenResponse;
 
     if (result?.data?.[0]?.access_token) {
-      return result.data[0].access_token;
+      this.accessToken = result.data[0].access_token;
+      return;
     }
 
     throw new IntegrationProviderAuthenticationError({

--- a/src/onelogin/OneLoginClient.ts
+++ b/src/onelogin/OneLoginClient.ts
@@ -33,7 +33,7 @@ interface AccessToken {
 export interface Account {
   id: string;
   name: string;
-  orgUrl: string | undefined;
+  orgUrl: string | undefined | null;
 }
 
 export interface User {
@@ -153,14 +153,17 @@ enum Method {
 }
 
 export default class OneLoginClient {
-  private host: string = 'https://api.us.onelogin.com';
+  private host: string;
   private accessToken: string;
 
   constructor(
     private clientId: string,
     private clientSecret: string,
     private readonly logger: IntegrationLogger,
-  ) {}
+    host?: string | null,
+  ) {
+    this.host = host || 'https://api.us.onelogin.com';
+  }
 
   public async authenticate() {
     const result = (await this.makeRequest(

--- a/src/validateInvocation.test.ts
+++ b/src/validateInvocation.test.ts
@@ -38,6 +38,22 @@ test('should succeed with valid credentials', async () => {
   await expect(validateInvocation(executionContext)).resolves.toBeUndefined();
 });
 
+test('should succeed when provided API hostname', async () => {
+  recording = setupRecording({
+    directory: __dirname,
+    name: 'validateInvocation:success:providedApiHostname',
+  });
+
+  const executionContext = createMockExecutionContext({
+    instanceConfig: {
+      ...integrationConfig,
+      apiHostname: 'https://api.us.onelogin.com',
+    },
+  });
+
+  await expect(validateInvocation(executionContext)).resolves.toBeUndefined();
+});
+
 test('should fail if Client ID is invalid', async () => {
   recording = setupRecording({
     directory: __dirname,


### PR DESCRIPTION
```
### Added

- Added the ability to pass a different API hostname (e.g.
  `https://api.eu.onelogin.com`) to fetch data from different OneLogin
  environments.

### Fixed

- Fixed an issue introduced in 2.0.2 that inadvertantly stopped referencing the
  `authToken` returned from the `/oauth2/token` call.
```