### PR TITLE
Pass hostname through APIClient to OneLoginClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [2.1.1] 2021-08-05
+
+### Fixed
+
+- Passed hostname through `APIClient` to `OneLoginClient`.
+
 ## [2.1.0] 2021-08-05
 
 ### Added

--- a/docs/jupiterone.md
+++ b/docs/jupiterone.md
@@ -64,11 +64,12 @@ be found [here][1].
 
 This integration's authentication is achieved by fetching an OAuth token from
 OneLogin. You can reproduce this authentication strategy by running the
-following curl, replacing `<CLIENT_ID>` and `<CLIENT_SECRET>` with your own:
+following curl, replacing `<CLIENT_ID>` and `<CLIENT_SECRET>` with your own.
+`<API_HOSTNAME>` defaults to `https://api.us.onelogin.com`:
 
 ```
 curl --request POST \
-  --url https://api.us.onelogin.com/auth/oauth2/v2/token \
+  --url <API_HOSTNAME> \
   --header 'authorization: client_id:<CLIENT_ID>, client_secret:<CLIENT_SECRET>' \
   --header 'content-type: application/json' \
   --data '{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@jupiterone/graph-onelogin",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "A JupiterOne managed integration for https://www.onelogin.com",
   "main": "dist/index.js",
   "repository": "https://github.com/jupiterone-io/graph-onelogin",

--- a/src/client.test.ts
+++ b/src/client.test.ts
@@ -1,0 +1,15 @@
+import { createMockIntegrationLogger } from '@jupiterone/integration-sdk-testing';
+import { createAPIClient } from './client';
+import { IntegrationConfig } from './config';
+
+test('should recieve apihostname from config', () => {
+  const config: IntegrationConfig = {
+    apiHostname: 'https://api.eu.onelogin.com',
+    clientId: 'client-id',
+    clientSecret: 'client-secret',
+  };
+
+  expect(
+    createAPIClient(config, createMockIntegrationLogger()).provider.host,
+  ).toBe('https://api.eu.onelogin.com');
+});

--- a/src/client.ts
+++ b/src/client.ts
@@ -29,6 +29,7 @@ export class APIClient {
       config.clientId,
       config.clientSecret,
       logger,
+      config.apiHostname,
     );
   }
 

--- a/src/onelogin/OneLoginClient.ts
+++ b/src/onelogin/OneLoginClient.ts
@@ -153,7 +153,7 @@ enum Method {
 }
 
 export default class OneLoginClient {
-  private host: string;
+  readonly host: string;
   private accessToken: string;
 
   constructor(


### PR DESCRIPTION
This project has two levels of clients, and I didn't pass the `config.apiHostname through the APIClient to the OneLoginClient.