### PR TITLE
INT-1728- Always create `onelogin_user` **ASSIGNED** `mfa_device`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+- Always create `onelogin_user` **ASSIGNED** `mfa_device` relationship even if
+  we've already seen the same `mfa_device`
+
 ## 2.2.11 - 2021-09-13
 
 ### Fixed

--- a/src/steps/userdevices.ts
+++ b/src/steps/userdevices.ts
@@ -46,11 +46,11 @@ export async function fetchUserDevices({
           },
           'Duplicate device found. Skipping.',
         );
-        return;
+      } else {
+        await jobState.addEntity(rawDeviceEntity);
       }
 
-      const deviceEntity = await jobState.addEntity(rawDeviceEntity);
-      mfaDeviceKeySet.add(deviceEntity._key);
+      mfaDeviceKeySet.add(rawDeviceEntity._key);
 
       await jobState.addRelationship(
         createDirectRelationship({
@@ -58,7 +58,7 @@ export async function fetchUserDevices({
           fromType: USER_ENTITY_TYPE,
           toType: PERSONAL_DEVICE_ENTITY_TYPE,
           fromKey: userEntity._key,
-          toKey: deviceEntity._key,
+          toKey: rawDeviceEntity._key,
         }),
       );
     });


### PR DESCRIPTION
relationship even if we've already seen the same `mfa_device`